### PR TITLE
feat(ui): show app version in footer (#14)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Grid } from './components/Grid';
 import { Toolbar } from './components/Toolbar';
 import { WinOverlay } from './components/WinOverlay';
 import { PairStatus } from './components/PairStatus';
+import { Footer } from './components/Footer';
 
 export default function App() {
   const {
@@ -72,6 +73,8 @@ export default function App() {
       </button>
 
       <PairStatus endpoints={puzzle.endpoints} statuses={pairStatuses} />
+
+      <Footer />
 
       {solved && (
         <WinOverlay

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,17 @@
+import { APP_VERSION, BUILD_SHA, RELEASE_URL } from '../lib/version';
+
+export function Footer() {
+  return (
+    <footer className="footer">
+      <a
+        className="footer__version"
+        href={RELEASE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`build ${BUILD_SHA} · open source, no accounts, no ads, no tracking. Generator under AGPL-3.0; everything else MIT.`}
+      >
+        v{APP_VERSION}
+      </a>
+    </footer>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -235,6 +235,21 @@ body, #root {
 }
 .pair-dot.partial { opacity: 0.55; }
 
+/* ── FOOTER ── */
+.footer {
+  width: 100%; display: flex; justify-content: center;
+  margin-top: 16px; padding-top: 8px;
+}
+.footer__version {
+  font-size: 11px;
+  color: var(--text-muted);
+  opacity: 0.5;
+  text-decoration: none;
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, monospace;
+  transition: opacity 0.15s;
+}
+.footer__version:hover { opacity: 0.9; }
+
 /* ── HINT OVERLAYS ── */
 .hint-overlay {
   position: absolute; inset: 8%; z-index: 8;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,7 @@
+declare const __APP_VERSION__: string;
+declare const __BUILD_SHA__: string;
+
+export const APP_VERSION: string = __APP_VERSION__;
+export const BUILD_SHA: string = __BUILD_SHA__;
+export const REPO_URL = 'https://github.com/arechste/arukone';
+export const RELEASE_URL = `${REPO_URL}/releases/tag/v${APP_VERSION}`;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,30 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf8'),
+) as { version: string }
+
+function gitShortSha(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim()
+  } catch {
+    return 'unknown'
+  }
+}
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __BUILD_SHA__: JSON.stringify(gitShortSha()),
+  },
   test: {
     globals: true,
     environment: 'happy-dom',


### PR DESCRIPTION
Closes #14.

## Summary

- Vite `define:` injects `__APP_VERSION__` (from `package.json`) and `__BUILD_SHA__` (from `git rev-parse --short HEAD`, falls back to `unknown` if git unavailable)
- `src/lib/version.ts` re-exports them with typed surface + `RELEASE_URL` helper
- New `<Footer />` renders a tiny `v0.2.0` link to the GitHub release tag, styled muted/monospace, slots below `PairStatus`
- Disclaimer copy ("no accounts, no ads, no tracking. Generator under AGPL-3.0; everything else MIT.") lives in the link's `title` attr — proper modal home is #12 (help overlay)

## Tradeoffs

Footer-only for now; full disclaimer modal pairs with #12 to avoid two modal components. Build SHA shown only in the title attr, not on screen — keeps the footer to one tiny line.

## Test plan

- [ ] Preview deploy shows `v0.2.0` in footer linking to release tag
- [ ] Hover/long-press on version surfaces disclaimer
- [ ] Theme toggle leaves footer styled correctly (light + dark)
- [ ] Bumping `package.json` version updates the rendered string on next build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
