### PR TITLE
fix(ui): theme cascade + responsive layout (#2 #3 #4)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useGameState } from './hooks/useGameState';
-import { getThemeVars } from './lib/theme';
 import { Header } from './components/Header';
 import { DifficultyPicker } from './components/DifficultyPicker';
 import { Grid } from './components/Grid';
@@ -19,11 +18,10 @@ export default function App() {
     getCellContent, formatTime,
   } = useGameState();
 
-  const themeVars = getThemeVars(theme);
   const connectedCount = pairStatuses.filter(s => s === 'connected').length;
 
   return (
-    <div className="app" style={themeVars as React.CSSProperties}>
+    <div className="app">
       <Header theme={theme} onToggleTheme={handleToggleTheme} />
 
       <DifficultyPicker

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,4 +1,5 @@
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { getThemeVars } from '../lib/theme';
 import type { GameStats, PairStatus } from '../lib/types';
 import { cellKey, getDailySeed } from '../lib/gameLogic';
 import { loadPuzzle, getDifficulties } from '../lib/puzzles';
@@ -86,6 +87,13 @@ export function useGameState() {
   const handleToggleTheme = useCallback(() => {
     setTheme(t => t === 'dark' ? 'light' : 'dark');
   }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const vars = getThemeVars(theme);
+    for (const [k, v] of Object.entries(vars)) root.style.setProperty(k, v);
+    root.dataset.theme = theme;
+  }, [theme]);
 
   const handleHint = useCallback(() => {
     if (hintMap) {

--- a/src/index.css
+++ b/src/index.css
@@ -2,15 +2,20 @@
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
-body, #root {
+html, body, #root {
   font-family: system-ui, -apple-system, sans-serif;
   min-height: 100dvh;
   -webkit-user-select: none; user-select: none;
   -webkit-touch-callout: none;
   overflow-y: auto;
   margin: 0;
-  background: var(--bg, #0c0c14);
+  background: var(--bg);
+  color: var(--text);
 }
+
+/* Reserved chrome height (header + difficulty + stats + toolbar + pair-status + footer + paddings).
+   Used to bound the grid by viewport height so it never pushes controls off-screen. */
+:root { --chrome-h: 320px; }
 
 /* ── LAYOUT ── */
 .app {
@@ -115,7 +120,11 @@ body, #root {
 
 /* ── GRID ── */
 .grid-wrapper {
-  position: relative; width: 100%;
+  position: relative;
+  /* Bind by both axes: never wider than the column, never taller than viewport minus chrome.
+     Keeps the grid square (aspect-ratio: 1 below) and prevents iPad-landscape overflow. */
+  width: min(100%, calc(100dvh - var(--chrome-h)));
+  aspect-ratio: 1;
   max-width: 480px;
   background: var(--grid-line);
   border-radius: 14px;
@@ -286,8 +295,8 @@ body, #root {
 
 /* Tablet / iPad (768px+) */
 @media (min-width: 768px) {
-  .app { max-width: 600px; padding: 20px 24px 32px; }
-  .grid-wrapper { max-width: 540px; }
+  .app { max-width: 720px; padding: 20px 24px 32px; }
+  .grid-wrapper { max-width: 600px; }
   .logo { font-size: 26px; }
   .btn { padding: 10px 20px; font-size: 14px; }
   .stat { font-size: 14px; }
@@ -297,16 +306,28 @@ body, #root {
 
 /* Large iPad / desktop (1024px+) */
 @media (min-width: 1024px) {
-  .app { max-width: 640px; }
-  .grid-wrapper { max-width: 580px; }
+  .app { max-width: 880px; }
+  .grid-wrapper { max-width: 720px; }
 }
 
-/* Landscape phones — constrain height */
+/* Wide desktop (1440px+) */
+@media (min-width: 1440px) {
+  .app { max-width: 960px; }
+  .grid-wrapper { max-width: 800px; }
+}
+
+/* Landscape phones — constrain height (tighter chrome) */
 @media (max-height: 500px) and (orientation: landscape) {
+  :root { --chrome-h: 240px; }
   .app { padding: 6px 12px 10px; }
   .header { margin-bottom: 4px; }
   .controls { margin-bottom: 6px; }
   .stats { margin-bottom: 6px; padding: 4px 2px; }
   .actions { margin-top: 6px; }
   .pair-status { margin-top: 6px; }
+}
+
+/* iPad landscape (tablet width, short viewport) */
+@media (min-width: 768px) and (max-height: 900px) and (orientation: landscape) {
+  :root { --chrome-h: 300px; }
 }


### PR DESCRIPTION
Closes #2, #3, #4.

**Stacked on top of #16** — review/merge that first, then this rebases cleanly onto `main`.

## Summary

Three related layout/theme bugs share one root: theme vars were scoped to `.app` and grid sizing only considered viewport width.

- **#2 (theme)**: `useGameState` writes theme vars to `documentElement` via `useEffect`, so `html`/`body` inherit `--bg`. Removed inline `style` from `.app` and the unused `getThemeVars` import in `App.tsx`. Added `data-theme` attr on root for any future theme-conditional selectors.
- **#3 (desktop)**: raised `.app` max-width to 720/880/960 at 768/1024/1440 breakpoints, and `.grid-wrapper` to 600/720/800. Wide desktop now gets a usably-sized grid instead of a phone-narrow column.
- **#4 (iPad landscape)**: `.grid-wrapper` width is `min(100%, calc(100dvh - var(--chrome-h)))` with `aspect-ratio: 1`. `--chrome-h` is 320px default, 240px short-landscape, 300px iPad-landscape. Grid now never pushes the toolbar/footer off-screen.

## Tradeoffs

- `--chrome-h` is an estimate, not measured. Adequate for the current static layout; if rows get added later, bump the constant. ResizeObserver-based measurement would be overkill.
- Wide-desktop ceiling caps at 800px grid — deliberate, to avoid a stretched-ear-to-ear feel on big monitors.

## Test plan

- [ ] Light mode: page background matches content (no dark margins)
- [ ] Dark mode: page background dark; toggle round-trips cleanly
- [ ] Desktop ≥1024px: Extreme grid visibly larger than on phone
- [ ] iPad landscape: full UI visible without scrolling on Easy + Extreme
- [ ] iPhone portrait: layout unchanged (max-width 520, grid 480)
- [ ] iPhone landscape: shorter chrome doesn't clip grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
