### PR TITLE
feat(ci): Playwright smoke against preview after deploy (#11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
     environment:
       name: preview
       url: ${{ steps.deploy.outputs.deployment-url }}
+    outputs:
+      url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -103,6 +105,41 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --env preview
           wranglerVersion: "4"
+
+  smoke:
+    needs: deploy-preview
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium webkit
+      - name: Run smoke tests against preview
+        env:
+          SMOKE_URL: ${{ needs.deploy-preview.outputs.url }}
+        run: bunx playwright test
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+      - name: Upload screenshots / traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-results
+          path: test-results/
+          retention-days: 7
 
   deploy-production:
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ dist
 *.swp
 .idea/
 
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/
+
 # Secrets — never commit
 .env
 .env.local

--- a/.mise.toml
+++ b/.mise.toml
@@ -19,6 +19,10 @@ run = "mise run dev"
 description = "Run tests"
 run = "bunx vitest run"
 
+[tasks.smoke]
+description = "Run Playwright smoke tests (set SMOKE_URL for remote target)"
+run = "bunx playwright test"
+
 [tasks.lint]
 description = "Run ESLint"
 run = "bun run lint"

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -114,6 +115,8 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
 
@@ -473,6 +476,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
@@ -594,6 +601,8 @@
     "@typescript-eslint/typescript-estree/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "smoke": "playwright test"
   },
   "dependencies": {
     "react": "^19.2.4",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.SMOKE_URL ?? 'http://localhost:5173';
+
+export default defineConfig({
+  testDir: './tests/smoke',
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop-1440',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
+    },
+    {
+      name: 'ipad-landscape',
+      use: { ...devices['iPad (gen 7) landscape'] },
+    },
+    {
+      name: 'phone-375',
+      use: { ...devices['iPhone 13 mini'] },
+    },
+  ],
+});

--- a/tests/smoke/preview.spec.ts
+++ b/tests/smoke/preview.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('preview smoke', () => {
+  test('loads with no console errors', async ({ page }, testInfo) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await page.goto('/');
+    await expect(page.locator('.app')).toBeVisible();
+    await expect(page.locator('.logo')).toHaveText(/arukone/i);
+
+    await testInfo.attach('viewport.png', {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([]);
+  });
+
+  test('security headers present', async ({ request }) => {
+    const res = await request.get('/');
+    expect(res.status()).toBe(200);
+    const headers = res.headers();
+    // Only meaningful when running against the real preview, not local Vite.
+    if (process.env.SMOKE_URL) {
+      expect(headers['content-security-policy'], 'CSP header').toBeTruthy();
+      expect(headers['strict-transport-security'], 'HSTS header').toBeTruthy();
+      expect(headers['x-content-type-options']).toBe('nosniff');
+    }
+  });
+
+  test('difficulty picker switches puzzle', async ({ page }) => {
+    await page.goto('/');
+    for (const label of ['Easy', 'Medium', 'Hard', 'Extreme']) {
+      const btn = page.getByRole('button', { name: new RegExp(`^${label}`, 'i') });
+      await btn.click();
+      await expect(page.locator('.grid-wrapper')).toBeVisible();
+    }
+  });
+
+  test('version footer links to release', async ({ page }) => {
+    await page.goto('/');
+    const versionLink = page.locator('.footer__version');
+    await expect(versionLink).toBeVisible();
+    const href = await versionLink.getAttribute('href');
+    expect(href).toMatch(/github\.com\/arechste\/arukone\/releases\/tag\/v\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
Closes #11.

**Stacked on top of #16** (footer test references the version footer landed there). Review/merge #16 first, then this rebases cleanly onto `main`.

## Summary

Option A from the issue — CI-driven Playwright smoke. Runs after `deploy-preview` on push-to-main, against the freshly-deployed preview URL.

- `playwright.config.ts` with three projects: `desktop-1440` (Chromium), `ipad-landscape` (WebKit, iPad gen 7), `phone-375` (iPhone 13 mini)
- `tests/smoke/preview.spec.ts` with four checks per project:
  1. Page loads, no console errors, no `pageerror`s — full-page screenshot attached
  2. Security headers present (CSP, HSTS, `X-Content-Type-Options: nosniff`) — gated on `SMOKE_URL` so local Vite doesn't false-fail
  3. Difficulty picker round-trips Easy → Medium → Hard → Extreme
  4. Version footer links to the GitHub release tag
- New `smoke` CI job, `needs: deploy-preview`. Installs Chromium + WebKit. `playwright-report/` and `test-results/` uploaded as 7-day artifacts.
- `mise run smoke` for local runs (defaults to `localhost:5173`; set `SMOKE_URL` to test against any deployed URL).

## Production gating

Smoke runs on main pushes, not on tags. Tag-driven prod deploy now requires explicit reviewer approval (#13) — the manual gate is where smoke status gets checked. Auto-blocking prod on smoke failure isn't worth implementing right now (would need cross-workflow state).

## Tradeoffs

- WebKit ≠ Mobile Safari, but it's close enough for layout/rendering smoke. Real-device coverage is BrowserStack-tier work, deferred.
- No drawing-path test yet — pointer-capture interactions are fragile under headless and the manual approval gate is the safety net for those.
- Auto-issue-creation on failure deferred per the issue body — failed smoke just blocks the workflow run; reviewer triages from artifacts.

## Test plan

- [ ] Locally: `mise run dev` then `mise run smoke` → 12 tests pass
- [ ] PR CI green
- [ ] After merge, watch `smoke` job on main run against the deployed preview
- [ ] Inspect `playwright-report` artifact in the run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
