### PR TITLE
feat(ui): help overlay + post-win feedback widget (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ The deployed runtime contains zero AGPL code. See [`LICENSING.md`](./LICENSING.m
 for the full explanation and [`THIRD_PARTY_LICENSES.md`](./THIRD_PARTY_LICENSES.md)
 for runtime dependency licenses.
 
+## Privacy
+
+Nothing leaves the device. Stats, best times, dismissed-help flag, and
+puzzle ratings live in `localStorage` only — there is no server, no
+analytics, no telemetry, no cookies. A future opt-in beacon for
+aggregate puzzle ratings (to tune the generator) is on the roadmap and
+will be explicitly opt-in if it ships.
+
 ## Security
 
 See [`SECURITY.md`](./SECURITY.md) for vulnerability reporting.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Grid } from './components/Grid';
 import { Toolbar } from './components/Toolbar';
 import { WinOverlay } from './components/WinOverlay';
 import { PairStatus } from './components/PairStatus';
+import { Footer } from './components/Footer';
 
 export default function App() {
   const {
@@ -72,6 +73,8 @@ export default function App() {
       </button>
 
       <PairStatus endpoints={puzzle.endpoints} statuses={pairStatuses} />
+
+      <Footer />
 
       {solved && (
         <WinOverlay

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useGameState } from './hooks/useGameState';
-import { getThemeVars } from './lib/theme';
 import { Header } from './components/Header';
 import { DifficultyPicker } from './components/DifficultyPicker';
 import { Grid } from './components/Grid';
@@ -19,11 +18,10 @@ export default function App() {
     getCellContent, formatTime,
   } = useGameState();
 
-  const themeVars = getThemeVars(theme);
   const connectedCount = pairStatuses.filter(s => s === 'connected').length;
 
   return (
-    <div className="app" style={themeVars as React.CSSProperties}>
+    <div className="app">
       <Header theme={theme} onToggleTheme={handleToggleTheme} />
 
       <DifficultyPicker

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,8 @@
+import { useCallback } from 'react';
 import { useGameState } from './hooks/useGameState';
+import { useHelp } from './hooks/useHelp';
+import { useFeedback } from './hooks/useFeedback';
+import type { Rating } from './hooks/useFeedback';
 import { Header } from './components/Header';
 import { DifficultyPicker } from './components/DifficultyPicker';
 import { Grid } from './components/Grid';
@@ -6,10 +10,11 @@ import { Toolbar } from './components/Toolbar';
 import { WinOverlay } from './components/WinOverlay';
 import { PairStatus } from './components/PairStatus';
 import { Footer } from './components/Footer';
+import { HelpOverlay } from './components/HelpOverlay';
 
 export default function App() {
   const {
-    theme, difficulty, puzzle, timer, moves, solved,
+    theme, difficulty, puzzleIndex, puzzle, timer, moves, solved,
     hintMap, showSolution, stats, difficulties, pairStatuses,
     playerPaths, history, gridRef,
     handlePointerDown, handlePointerMove, handlePointerUp,
@@ -18,7 +23,19 @@ export default function App() {
     getCellContent, formatTime,
   } = useGameState();
 
+  const help = useHelp();
+  const feedback = useFeedback();
   const connectedCount = pairStatuses.filter(s => s === 'connected').length;
+
+  const handleRate = useCallback((rating: Rating) => {
+    feedback.record({
+      puzzleId: `${difficulty}-${puzzleIndex}`,
+      difficulty,
+      rating,
+      timeSeconds: timer,
+      ts: Date.now(),
+    });
+  }, [feedback, difficulty, puzzleIndex, timer]);
 
   return (
     <div className="app">
@@ -31,11 +48,11 @@ export default function App() {
       />
 
       <div className="stats">
-        <div className="stat">{'\u23F1'} <strong>{formatTime(timer)}</strong></div>
+        <div className="stat">{'⏱'} <strong>{formatTime(timer)}</strong></div>
         <div className="stat">
           <strong>{connectedCount}</strong> / {puzzle.pairs} pairs
         </div>
-        <div className="stat">{'\u2197'} <strong>{moves}</strong> moves</div>
+        <div className="stat">{'↗'} <strong>{moves}</strong> moves</div>
       </div>
 
       <Grid
@@ -57,6 +74,7 @@ export default function App() {
         onReset={handleReset}
         onNewPuzzle={handleNewPuzzle}
         onHint={handleHint}
+        onShowHelp={help.show}
       />
 
       <button
@@ -67,12 +85,22 @@ export default function App() {
           marginTop: 4,
         }}
       >
-        {showSolution ? '\u2298 hide solution' : '\u2299 debug'}
+        {showSolution ? '⊘ hide solution' : '⊙ debug'}
       </button>
 
       <PairStatus endpoints={puzzle.endpoints} statuses={pairStatuses} />
 
       <Footer />
+
+      {help.open && (
+        <HelpOverlay
+          difficultyLabel={difficulties[difficulty].label}
+          rows={puzzle.rows}
+          cols={puzzle.cols}
+          pairs={puzzle.pairs}
+          onClose={help.close}
+        />
+      )}
 
       {solved && (
         <WinOverlay
@@ -81,9 +109,10 @@ export default function App() {
           cols={puzzle.cols}
           timer={formatTime(timer)}
           moves={moves}
-          bestTime={stats.bestTimes[difficulty] ? formatTime(stats.bestTimes[difficulty]) : '\u2014'}
+          bestTime={stats.bestTimes[difficulty] ? formatTime(stats.bestTimes[difficulty]) : '—'}
           totalSolved={stats.totalSolved}
           onNextPuzzle={handleNewPuzzle}
+          onRate={handleRate}
         />
       )}
     </div>

--- a/src/components/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import type { Rating } from '../hooks/useFeedback';
+
+interface FeedbackWidgetProps {
+  onRate: (rating: Rating) => void;
+  onSkip: () => void;
+}
+
+const OPTIONS: { rating: Rating; label: string }[] = [
+  { rating: 'too_easy', label: 'Too easy' },
+  { rating: 'just_right', label: 'Just right' },
+  { rating: 'too_hard', label: 'Too hard' },
+  { rating: 'too_linear', label: 'Too linear' },
+];
+
+export function FeedbackWidget({ onRate, onSkip }: FeedbackWidgetProps) {
+  const [chosen, setChosen] = useState<Rating | null>(null);
+
+  if (chosen) {
+    return <p className="feedback-thanks">Thanks &mdash; that helps tune future puzzles.</p>;
+  }
+
+  return (
+    <div className="feedback">
+      <p className="feedback-prompt">How was that puzzle?</p>
+      <div className="feedback-buttons">
+        {OPTIONS.map(opt => (
+          <button
+            key={opt.rating}
+            className="btn btn--small"
+            onClick={() => {
+              setChosen(opt.rating);
+              onRate(opt.rating);
+            }}
+          >
+            {opt.label}
+          </button>
+        ))}
+        <button className="btn btn--small btn--ghost" onClick={onSkip}>
+          Skip
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,17 @@
+import { APP_VERSION, BUILD_SHA, RELEASE_URL } from '../lib/version';
+
+export function Footer() {
+  return (
+    <footer className="footer">
+      <a
+        className="footer__version"
+        href={RELEASE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`build ${BUILD_SHA} · open source, no accounts, no ads, no tracking. Generator under AGPL-3.0; everything else MIT.`}
+      >
+        v{APP_VERSION}
+      </a>
+    </footer>
+  );
+}

--- a/src/components/HelpOverlay.tsx
+++ b/src/components/HelpOverlay.tsx
@@ -1,0 +1,33 @@
+interface HelpOverlayProps {
+  difficultyLabel: string;
+  rows: number;
+  cols: number;
+  pairs: number;
+  onClose: () => void;
+}
+
+export function HelpOverlay({ difficultyLabel, rows, cols, pairs, onClose }: HelpOverlayProps) {
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="help-title">
+      <div className="modal-card">
+        <button className="modal-close" onClick={onClose} aria-label="Close help">×</button>
+        <h2 id="help-title">How to play</h2>
+        <p className="modal-context">
+          {difficultyLabel} &middot; {rows}&times;{cols} &middot; {pairs} pairs
+        </p>
+        <ol className="help-steps">
+          <li>Drag from one letter to its matching letter through empty cells.</li>
+          <li>Paths can&rsquo;t cross or overlap. Drag back to erase.</li>
+          <li>Fill every cell to win. Connecting all pairs alone isn&rsquo;t enough.</li>
+        </ol>
+        <p className="modal-fineprint">
+          Open source &middot; no accounts &middot; no ads &middot; no tracking. Plays
+          entirely in your browser. Generator under AGPL-3.0; everything else MIT.
+        </p>
+        <button className="btn btn--filled" onClick={onClose} style={{ marginTop: 8 }}>
+          Got it
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -6,9 +6,10 @@ interface ToolbarProps {
   onReset: () => void;
   onNewPuzzle: () => void;
   onHint: () => void;
+  onShowHelp: () => void;
 }
 
-export function Toolbar({ canUndo, canHint, hintActive, onUndo, onReset, onNewPuzzle, onHint }: ToolbarProps) {
+export function Toolbar({ canUndo, canHint, hintActive, onUndo, onReset, onNewPuzzle, onHint, onShowHelp }: ToolbarProps) {
   return (
     <div className="actions">
       <button className="btn" onClick={onUndo} disabled={!canUndo}>
@@ -27,6 +28,7 @@ export function Toolbar({ canUndo, canHint, hintActive, onUndo, onReset, onNewPu
       >
         {hintActive ? '✓ Hide' : '✓ Hint'}
       </button>
+      <button className="btn btn--icon" onClick={onShowHelp} aria-label="How to play">?</button>
     </div>
   );
 }

--- a/src/components/WinOverlay.tsx
+++ b/src/components/WinOverlay.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { PATH_COLORS } from '../lib/constants';
 import type { DifficultyConfig } from '../lib/types';
+import { FeedbackWidget } from './FeedbackWidget';
+import type { Rating } from '../hooks/useFeedback';
 
 interface WinOverlayProps {
   difficulty: DifficultyConfig;
@@ -11,6 +13,7 @@ interface WinOverlayProps {
   bestTime: string;
   totalSolved: number;
   onNextPuzzle: () => void;
+  onRate: (rating: Rating) => void;
 }
 
 function generateConfetti() {
@@ -40,7 +43,9 @@ function Confetti() {
   );
 }
 
-export function WinOverlay({ difficulty, rows, cols, timer, moves, bestTime, totalSolved, onNextPuzzle }: WinOverlayProps) {
+export function WinOverlay({ difficulty, rows, cols, timer, moves, bestTime, totalSolved, onNextPuzzle, onRate }: WinOverlayProps) {
+  const [feedbackDone, setFeedbackDone] = useState(false);
+
   return (
     <div className="win-overlay">
       <Confetti />
@@ -61,10 +66,16 @@ export function WinOverlay({ difficulty, rows, cols, timer, moves, bestTime, tot
             <div className="lbl">Best</div>
           </div>
         </div>
-        <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 20 }}>
+        <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 16 }}>
           {totalSolved} puzzle{totalSolved !== 1 ? 's' : ''} solved
         </p>
-        <button className="btn btn--filled" style={{ padding: '12px 32px', fontSize: 15 }} onClick={onNextPuzzle}>
+        {!feedbackDone && (
+          <FeedbackWidget
+            onRate={(r) => { onRate(r); setFeedbackDone(true); }}
+            onSkip={() => setFeedbackDone(true)}
+          />
+        )}
+        <button className="btn btn--filled" style={{ padding: '12px 32px', fontSize: 15, marginTop: 12 }} onClick={onNextPuzzle}>
           Next Puzzle &rarr;
         </button>
       </div>

--- a/src/hooks/useFeedback.ts
+++ b/src/hooks/useFeedback.ts
@@ -1,0 +1,43 @@
+import { useState, useCallback } from 'react';
+
+export type Rating = 'too_easy' | 'just_right' | 'too_hard' | 'too_linear';
+
+export interface FeedbackEntry {
+  puzzleId: string;
+  difficulty: string;
+  rating: Rating;
+  timeSeconds: number;
+  ts: number;
+}
+
+const STORAGE_KEY = 'arukone:ratings-v1';
+const MAX_ENTRIES = 500;
+
+function load(): FeedbackEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function useFeedback() {
+  const [entries, setEntries] = useState<FeedbackEntry[]>(load);
+
+  const record = useCallback((entry: FeedbackEntry) => {
+    setEntries(prev => {
+      const next = [...prev, entry].slice(-MAX_ENTRIES);
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        // quota exceeded — ignore, keep in-memory copy
+      }
+      return next;
+    });
+  }, []);
+
+  return { entries, record };
+}

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -231,7 +231,7 @@ export function useGameState() {
   }, [drawing, playerPaths, puzzle]);
 
   return {
-    theme, difficulty, puzzle, timer, moves, solved, started,
+    theme, difficulty, puzzleIndex, puzzle, timer, moves, solved, started,
     hintMap, showSolution, stats, difficulties, pairStatuses,
     playerPaths, drawing, history, gridRef,
     handlePointerDown, handlePointerMove, handlePointerUp,

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,4 +1,5 @@
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { getThemeVars } from '../lib/theme';
 import type { GameStats, PairStatus } from '../lib/types';
 import { cellKey, getDailySeed } from '../lib/gameLogic';
 import { loadPuzzle, getDifficulties } from '../lib/puzzles';
@@ -86,6 +87,13 @@ export function useGameState() {
   const handleToggleTheme = useCallback(() => {
     setTheme(t => t === 'dark' ? 'light' : 'dark');
   }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const vars = getThemeVars(theme);
+    for (const [k, v] of Object.entries(vars)) root.style.setProperty(k, v);
+    root.dataset.theme = theme;
+  }, [theme]);
 
   const handleHint = useCallback(() => {
     if (hintMap) {

--- a/src/hooks/useHelp.ts
+++ b/src/hooks/useHelp.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'arukone:help-dismissed-v1';
+
+function shouldShowOnLoad(): boolean {
+  // Escape hatch for automation (Playwright smoke, screenshots, demos).
+  try {
+    if (new URLSearchParams(window.location.search).has('nohelp')) return false;
+  } catch {
+    // ignore
+  }
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== '1';
+  } catch {
+    return true;
+  }
+}
+
+export function useHelp() {
+  const [open, setOpen] = useState(shouldShowOnLoad);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const show = useCallback(() => setOpen(true), []);
+
+  return { open, close, show };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,15 +2,20 @@
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
-body, #root {
+html, body, #root {
   font-family: system-ui, -apple-system, sans-serif;
   min-height: 100dvh;
   -webkit-user-select: none; user-select: none;
   -webkit-touch-callout: none;
   overflow-y: auto;
   margin: 0;
-  background: var(--bg, #0c0c14);
+  background: var(--bg);
+  color: var(--text);
 }
+
+/* Reserved chrome height (header + difficulty + stats + toolbar + pair-status + footer + paddings).
+   Used to bound the grid by viewport height so it never pushes controls off-screen. */
+:root { --chrome-h: 320px; }
 
 /* ── LAYOUT ── */
 .app {
@@ -115,7 +120,11 @@ body, #root {
 
 /* ── GRID ── */
 .grid-wrapper {
-  position: relative; width: 100%;
+  position: relative;
+  /* Bind by both axes: never wider than the column, never taller than viewport minus chrome.
+     Keeps the grid square (aspect-ratio: 1 below) and prevents iPad-landscape overflow. */
+  width: min(100%, calc(100dvh - var(--chrome-h)));
+  aspect-ratio: 1;
   max-width: 480px;
   background: var(--grid-line);
   border-radius: 14px;
@@ -286,8 +295,8 @@ body, #root {
 
 /* Tablet / iPad (768px+) */
 @media (min-width: 768px) {
-  .app { max-width: 600px; padding: 20px 24px 32px; }
-  .grid-wrapper { max-width: 540px; }
+  .app { max-width: 720px; padding: 20px 24px 32px; }
+  .grid-wrapper { max-width: 600px; }
   .logo { font-size: 26px; }
   .btn { padding: 10px 20px; font-size: 14px; }
   .stat { font-size: 14px; }
@@ -297,16 +306,28 @@ body, #root {
 
 /* Large iPad / desktop (1024px+) */
 @media (min-width: 1024px) {
-  .app { max-width: 640px; }
-  .grid-wrapper { max-width: 580px; }
+  .app { max-width: 880px; }
+  .grid-wrapper { max-width: 720px; }
 }
 
-/* Landscape phones — constrain height */
+/* Wide desktop (1440px+) */
+@media (min-width: 1440px) {
+  .app { max-width: 960px; }
+  .grid-wrapper { max-width: 800px; }
+}
+
+/* Landscape phones — constrain height (tighter chrome) */
 @media (max-height: 500px) and (orientation: landscape) {
+  :root { --chrome-h: 240px; }
   .app { padding: 6px 12px 10px; }
   .header { margin-bottom: 4px; }
   .controls { margin-bottom: 6px; }
   .stats { margin-bottom: 6px; padding: 4px 2px; }
   .actions { margin-top: 6px; }
   .pair-status { margin-top: 6px; }
+}
+
+/* iPad landscape (tablet width, short viewport) */
+@media (min-width: 768px) and (max-height: 900px) and (orientation: landscape) {
+  :root { --chrome-h: 300px; }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -235,6 +235,21 @@ body, #root {
 }
 .pair-dot.partial { opacity: 0.55; }
 
+/* ── FOOTER ── */
+.footer {
+  width: 100%; display: flex; justify-content: center;
+  margin-top: 16px; padding-top: 8px;
+}
+.footer__version {
+  font-size: 11px;
+  color: var(--text-muted);
+  opacity: 0.5;
+  text-decoration: none;
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, monospace;
+  transition: opacity 0.15s;
+}
+.footer__version:hover { opacity: 0.9; }
+
 /* ── HINT OVERLAYS ── */
 .hint-overlay {
   position: absolute; inset: 8%; z-index: 8;

--- a/src/index.css
+++ b/src/index.css
@@ -259,6 +259,76 @@ html, body, #root {
 }
 .footer__version:hover { opacity: 0.9; }
 
+/* ── MODAL (help overlay) ── */
+.modal-overlay {
+  position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+  background: var(--overlay); z-index: 200;
+  display: flex; align-items: center; justify-content: center;
+  padding: 16px;
+  animation: fadeIn 0.2s ease;
+}
+.modal-card {
+  background: var(--surface); color: var(--text);
+  border-radius: 16px; padding: 28px 28px 24px;
+  max-width: 380px; width: 100%;
+  position: relative;
+  border: 1px solid var(--grid-line);
+  box-shadow: var(--shadow);
+  animation: popIn 0.25s ease;
+}
+.modal-card h2 {
+  font-size: 20px; font-weight: 700; margin-bottom: 4px;
+  color: var(--accent);
+}
+.modal-context {
+  font-size: 12px; color: var(--text-muted);
+  margin-bottom: 16px; font-variant-numeric: tabular-nums;
+}
+.modal-close {
+  position: absolute; top: 8px; right: 12px;
+  background: none; border: none; color: var(--text-muted);
+  font-size: 22px; line-height: 1; cursor: pointer;
+  padding: 4px 8px;
+}
+.modal-close:hover { color: var(--text); }
+.modal-fineprint {
+  font-size: 11px; color: var(--text-muted);
+  line-height: 1.5; margin: 16px 0 4px;
+}
+.help-steps {
+  list-style: decimal inside;
+  font-size: 14px; line-height: 1.6;
+  margin-bottom: 8px;
+  padding-left: 4px;
+}
+.help-steps li { margin-bottom: 6px; }
+
+/* ── FEEDBACK WIDGET ── */
+.feedback {
+  border-top: 1px solid var(--grid-line);
+  padding-top: 14px; margin-top: 4px;
+}
+.feedback-prompt {
+  font-size: 12px; color: var(--text-muted);
+  margin-bottom: 8px;
+}
+.feedback-buttons {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  justify-content: center;
+}
+.feedback-thanks {
+  font-size: 12px; color: var(--text-muted);
+  margin: 14px 0 4px; font-style: italic;
+}
+.btn--small {
+  padding: 6px 12px; font-size: 12px;
+}
+.btn--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--text-muted);
+}
+
 /* ── HINT OVERLAYS ── */
 .hint-overlay {
   position: absolute; inset: 8%; z-index: 8;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,7 @@
+declare const __APP_VERSION__: string;
+declare const __BUILD_SHA__: string;
+
+export const APP_VERSION: string = __APP_VERSION__;
+export const BUILD_SHA: string = __BUILD_SHA__;
+export const REPO_URL = 'https://github.com/arechste/arukone';
+export const RELEASE_URL = `${REPO_URL}/releases/tag/v${APP_VERSION}`;

--- a/tests/components/App.test.tsx
+++ b/tests/components/App.test.tsx
@@ -5,12 +5,14 @@ import App from '../../src/App';
 describe('App', () => {
   beforeEach(() => {
     localStorage.clear();
+    // suppress first-visit help overlay so it doesn't shadow text queries
+    localStorage.setItem('arukone:help-dismissed-v1', '1');
   });
 
   it('renders the game', () => {
     render(<App />);
-    expect(screen.getByText(/Easy/)).toBeInTheDocument();
-    expect(screen.getByText(/Medium/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Easy/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Medium/ })).toBeInTheDocument();
     expect(screen.getByText(/moves/)).toBeInTheDocument();
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,30 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const pkg = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./package.json', import.meta.url)), 'utf8'),
+) as { version: string }
+
+function gitShortSha(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim()
+  } catch {
+    return 'unknown'
+  }
+}
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __BUILD_SHA__: JSON.stringify(gitShortSha()),
+  },
   test: {
     globals: true,
     environment: 'happy-dom',


### PR DESCRIPTION
Closes #12.

**Stacked on top of #17** (uses the theme cascade and Footer landed there). Review/merge order: #16 → #17 → this. After all three, this rebases cleanly to `main`.

## Summary

Phase A only — local storage, no beacon. Two additions:

### Help overlay
- First-visit modal (per device) with the three core rules + current difficulty / size / pair count
- Dismissed via "Got it" or X. Persisted in `localStorage` as `arukone:help-dismissed-v1`
- Resurfaceable via a new `?` icon in the toolbar
- Disclaimer copy ("open source, no accounts, no ads, no tracking, generator AGPL-3.0 / runtime MIT") moves from the footer's `title` attribute into the modal body where it actually gets read
- `?nohelp` query param suppresses the first-visit modal — escape hatch for Playwright smoke / screenshots / demos so they don't have to deal with it

### Feedback widget
- 4-button rating shown in the win overlay: Too easy / Just right / Too hard / Too linear, plus Skip
- Stored locally in `arukone:ratings-v1` (capped at last 500 entries), keyed by `${difficulty}-${puzzleIndex}` with `{rating, timeSeconds, ts}`
- After tap: "Thanks — that helps tune future puzzles." No second-tap comment field yet — keeping the path tight

### README
Adds a Privacy section explicitly stating nothing leaves the device. Per the issue's Boundaries: any future telemetry must be opt-in.

## Tradeoffs

- Single shared modal component (`HelpOverlay`) — no need for two different modals when one structure fits both invocations
- Skipped Phase B (Cloudflare Worker beacon) and Phase 2 (`tools/calibrate.py`) — both are real follow-up work, not in scope here
- Test fixture: `App.test.tsx` now sets `arukone:help-dismissed-v1` in `beforeEach` so the modal doesn't shadow the existing text queries; existing assertions tightened to `getByRole('button', { name: ... })` where they were ambiguous

## Test plan

- [ ] First load: help modal shows, "Got it" dismisses, doesn't reappear on reload
- [ ] `?` button in toolbar reopens the modal
- [ ] `?nohelp` query suppresses first-visit modal
- [ ] Solve a puzzle, tap a rating button, verify entry appears in `localStorage` (`arukone:ratings-v1`)
- [ ] Skip leaves no entry but transitions UI to "thanks" state for that win
- [ ] Theme: modal styles correctly in light + dark
- [ ] Smoke (after #11 lands too): `mise run smoke` still green; smoke spec may want `?nohelp` or `localStorage` set in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
